### PR TITLE
Uses custom DateProvider instead of JodaTime

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,8 +40,6 @@ publish {
 }
 
 dependencies {
-    compile 'joda-time:joda-time:2.3'
-
     testCompile 'org.mockito:mockito-all:1.8.4'
 }
 

--- a/src/main/java/com/fewlaps/quitnowcache/DateProvider.java
+++ b/src/main/java/com/fewlaps/quitnowcache/DateProvider.java
@@ -1,6 +1,6 @@
 package com.fewlaps.quitnowcache;
 
-public interface DateProvider {
+interface DateProvider {
 
     long now();
 

--- a/src/main/java/com/fewlaps/quitnowcache/DateProvider.java
+++ b/src/main/java/com/fewlaps/quitnowcache/DateProvider.java
@@ -1,0 +1,14 @@
+package com.fewlaps.quitnowcache;
+
+public interface DateProvider {
+
+    long now();
+
+    DateProvider SYSTEM = new DateProvider() {
+
+        @Override
+        public long now() {
+            return System.currentTimeMillis();
+        }
+    };
+}

--- a/src/main/java/com/fewlaps/quitnowcache/QNCache.java
+++ b/src/main/java/com/fewlaps/quitnowcache/QNCache.java
@@ -1,7 +1,5 @@
 package com.fewlaps.quitnowcache;
 
-import org.joda.time.DateTime;
-
 import java.util.Iterator;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -13,6 +11,7 @@ public class QNCache {
 
     private boolean caseSensitiveKeys = true;
     private Integer autoReleaseInSeconds = null;
+    private DateProvider dateProvider = DateProvider.SYSTEM;
 
     public QNCache(boolean caseSensitiveKeys, Integer autoReleaseInSeconds) {
         this.caseSensitiveKeys = caseSensitiveKeys;
@@ -47,7 +46,11 @@ public class QNCache {
     }
 
     private long now() {
-        return new DateTime().toDate().getTime();
+        return dateProvider.now();
+    }
+
+    protected void setDateProvider(DateProvider dateProvider) {
+        this.dateProvider = dateProvider;
     }
 
     private ConcurrentHashMap<String, QNCacheBean> cache;

--- a/src/test/java/com/fewlaps/quitnowcache/CastTest.java
+++ b/src/test/java/com/fewlaps/quitnowcache/CastTest.java
@@ -2,7 +2,6 @@ package com.fewlaps.quitnowcache;
 
 import com.fewlaps.quitnowcache.bean.ObjectTestOne;
 import com.fewlaps.quitnowcache.bean.ObjectTestTwo;
-import org.joda.time.DateTimeUtils;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -15,7 +14,6 @@ public class CastTest extends BaseTest {
 
     @Before
     public void init() {
-        DateTimeUtils.setCurrentMillisSystem();
         cache = new QNCacheBuilder().createQNCache();
     }
 

--- a/src/test/java/com/fewlaps/quitnowcache/IntroducingQNCacheTest.java
+++ b/src/test/java/com/fewlaps/quitnowcache/IntroducingQNCacheTest.java
@@ -1,6 +1,5 @@
 package com.fewlaps.quitnowcache;
 
-import org.joda.time.DateTimeUtils;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -10,7 +9,6 @@ public class IntroducingQNCacheTest {
 
     @Before
     public void init() {
-        DateTimeUtils.setCurrentMillisSystem();
     }
 
     @Test

--- a/src/test/java/com/fewlaps/quitnowcache/MassiveDataTest.java
+++ b/src/test/java/com/fewlaps/quitnowcache/MassiveDataTest.java
@@ -1,6 +1,5 @@
 package com.fewlaps.quitnowcache;
 
-import org.joda.time.DateTimeUtils;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -11,7 +10,6 @@ public class MassiveDataTest extends BaseTest {
 
     @Before
     public void init() {
-        DateTimeUtils.setCurrentMillisSystem();
         cache = new QNCacheBuilder().createQNCache();
     }
 

--- a/src/test/java/com/fewlaps/quitnowcache/MemoryReleaseTest.java
+++ b/src/test/java/com/fewlaps/quitnowcache/MemoryReleaseTest.java
@@ -1,6 +1,5 @@
 package com.fewlaps.quitnowcache;
 
-import org.joda.time.DateTimeUtils;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -10,7 +9,6 @@ public class MemoryReleaseTest extends BaseTest {
 
     @Before
     public void init() {
-        DateTimeUtils.setCurrentMillisSystem();
     }
 
     @Test

--- a/src/test/java/com/fewlaps/quitnowcache/MockDateProvider.java
+++ b/src/test/java/com/fewlaps/quitnowcache/MockDateProvider.java
@@ -1,0 +1,19 @@
+package com.fewlaps.quitnowcache;
+
+public class MockDateProvider implements DateProvider {
+
+    private Long fakeNow;
+
+    public void setFixed(long fakeNow) {
+        this.fakeNow = fakeNow;
+    }
+
+    public void setSystem() {
+        this.fakeNow = null;
+    }
+
+    @Override
+    public long now() {
+        return fakeNow != null ? fakeNow : DateProvider.SYSTEM.now();
+    }
+}

--- a/src/test/java/com/fewlaps/quitnowcache/SetAndGetValuesTest.java
+++ b/src/test/java/com/fewlaps/quitnowcache/SetAndGetValuesTest.java
@@ -1,6 +1,5 @@
 package com.fewlaps.quitnowcache;
 
-import org.joda.time.DateTimeUtils;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -9,11 +8,13 @@ import static org.junit.Assert.*;
 public class SetAndGetValuesTest extends BaseTest {
 
     QNCache cache;
+    MockDateProvider dateProvider;
 
     @Before
     public void init() {
-        DateTimeUtils.setCurrentMillisSystem();
         cache = new QNCacheBuilder().createQNCache();
+        dateProvider = new MockDateProvider();
+        cache.setDateProvider(dateProvider);
     }
 
     @Test
@@ -34,7 +35,7 @@ public class SetAndGetValuesTest extends BaseTest {
     public void savingSomethingWithoudSpecifyingTheKeepaliveValueShouldReturnTheSameAfterThreeDays() {
         cache.set(A_KEY, A_VALUE);
 
-        DateTimeUtils.setCurrentMillisFixed(threeDaysFromNow());
+        dateProvider.setFixed(threeDaysFromNow());
 
         assertEquals(A_VALUE, cache.get(A_KEY));
     }
@@ -43,7 +44,7 @@ public class SetAndGetValuesTest extends BaseTest {
     public void savingSomethingForeverShouldReturnTheSameAfterThreeDays() {
         cache.set(A_KEY, A_VALUE, FOREVER);
 
-        DateTimeUtils.setCurrentMillisFixed(threeDaysFromNow());
+        dateProvider.setFixed(threeDaysFromNow());
 
         assertEquals(A_VALUE, cache.get(A_KEY));
     }
@@ -52,7 +53,7 @@ public class SetAndGetValuesTest extends BaseTest {
     public void savingAValueForTwoHoursShouldReturnNullAfterThreeDays() {
         cache.set(A_KEY, A_VALUE, TWO_HOURS);
 
-        DateTimeUtils.setCurrentMillisFixed(threeDaysFromNow());
+        dateProvider.setFixed(threeDaysFromNow());
 
         assertNull(cache.get(A_KEY));
     }
@@ -82,7 +83,7 @@ public class SetAndGetValuesTest extends BaseTest {
         cache.set(A_KEY, A_VALUE, ONE_SECOND);
         cache.set(ANOTHER_KEY, ANOTHER_VALUE, THREE_DAYS);
 
-        DateTimeUtils.setCurrentMillisFixed(twoHoursFromNow());
+        dateProvider.setFixed(twoHoursFromNow());
 
         assertNull(cache.getAndRemoveIfDead(A_KEY));
         assertEquals(1, cache.size());
@@ -94,7 +95,7 @@ public class SetAndGetValuesTest extends BaseTest {
         cache.set(A_KEY, A_VALUE, ONE_SECOND);
         cache.set(ANOTHER_KEY, ANOTHER_VALUE, THREE_DAYS);
 
-        DateTimeUtils.setCurrentMillisFixed(twoHoursFromNow());
+        dateProvider.setFixed(twoHoursFromNow());
 
         assertEquals(ANOTHER_VALUE, cache.getAndRemoveIfDead(ANOTHER_KEY));
         assertEquals(1, cache.size());
@@ -136,7 +137,7 @@ public class SetAndGetValuesTest extends BaseTest {
         cache.set(A_KEY, A_VALUE, THREE_DAYS);
         cache.set(A_KEY, ANOTHER_VALUE, ONE_SECOND);
 
-        DateTimeUtils.setCurrentMillisFixed(twoHoursFromNow());
+        dateProvider.setFixed(twoHoursFromNow());
 
         assertNull(cache.get(A_KEY));
     }

--- a/src/test/java/com/fewlaps/quitnowcache/SizeTest.java
+++ b/src/test/java/com/fewlaps/quitnowcache/SizeTest.java
@@ -1,6 +1,5 @@
 package com.fewlaps.quitnowcache;
 
-import org.joda.time.DateTimeUtils;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -9,11 +8,13 @@ import static org.junit.Assert.*;
 public class SizeTest extends BaseTest {
 
     QNCache cache;
+    MockDateProvider dateProvider;
 
     @Before
     public void init() {
-        DateTimeUtils.setCurrentMillisSystem();
         cache = new QNCacheBuilder().createQNCache();
+        dateProvider = new MockDateProvider();
+        cache.setDateProvider(dateProvider);
     }
 
     @Test
@@ -59,7 +60,7 @@ public class SizeTest extends BaseTest {
     public void sizeWorksAfterRemovingOldElements() {
         cache.set(A_KEY, A_VALUE, ONE_SECOND);
         cache.set(ANOTHER_KEY, ANOTHER_VALUE, THREE_DAYS);
-        DateTimeUtils.setCurrentMillisFixed(twoHoursFromNow());
+        dateProvider.setFixed(twoHoursFromNow());
 
         cache.removeTooOldValues();
 

--- a/src/test/java/com/fewlaps/quitnowcache/ThreadSafeTest.java
+++ b/src/test/java/com/fewlaps/quitnowcache/ThreadSafeTest.java
@@ -1,7 +1,6 @@
 package com.fewlaps.quitnowcache;
 
 import com.fewlaps.quitnowcache.util.RandomGenerator;
-import org.joda.time.DateTimeUtils;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -18,7 +17,6 @@ public class ThreadSafeTest extends BaseTest {
 
     @Before
     public void init() {
-        DateTimeUtils.setCurrentMillisSystem();
         cache = new QNCacheBuilder().createQNCache();
     }
 


### PR DESCRIPTION
Removing Joda Time avoids forcing clients of the library to include it. In Android it has some footprint like [bad initialization performance](http://blog.danlew.net/2013/08/20/joda_time_s_memory_issue_in_android/) and ~4605 methods added to the dex file. Also, including 'joda-time:joda-time:2.3' prevents the client from using [more lightweight approaches](https://github.com/dlew/joda-time-android) because of dependency conflicts.

This is one possible approach, doesn't have to be the best one. I will gladly accept any suggestions about it.

> Joda Time was being used for mocking the current date in the tests.
In order to remove the dependency and lighten de library I've created
a custom DateProvider interface with a default 'system' implementation
which always return System.currentTimeMillis(), and used it in QNCache.

> The dateProvider has a protected setter for replacing from in the tests.

> I've removed the redundant date configuration from the tests that didn't
need it, and used a MockDateProvider where a custom date was needed.