### PR TITLE
squid:S3052, squid:S1213 - Fields should not be initialized to defaul…

### DIFF
--- a/src/main/java/com/fewlaps/quitnowcache/DateProvider.java
+++ b/src/main/java/com/fewlaps/quitnowcache/DateProvider.java
@@ -2,8 +2,6 @@ package com.fewlaps.quitnowcache;
 
 interface DateProvider {
 
-    long now();
-
     DateProvider SYSTEM = new DateProvider() {
 
         @Override
@@ -11,4 +9,6 @@ interface DateProvider {
             return System.currentTimeMillis();
         }
     };
+
+    long now();
 }

--- a/src/main/java/com/fewlaps/quitnowcache/QNCache.java
+++ b/src/main/java/com/fewlaps/quitnowcache/QNCache.java
@@ -12,9 +12,10 @@ public class QNCache<T> {
     public static final long KEEPALIVE_FOREVER = 0;
 
     private boolean caseSensitiveKeys = true;
-    private Integer autoReleaseInSeconds = null;
-    private Long defaultKeepaliveInMillis = null;
+    private Integer autoReleaseInSeconds;
+    private Long defaultKeepaliveInMillis;
     private DateProvider dateProvider = DateProvider.SYSTEM;
+    private ConcurrentHashMap<String, QNCacheBean<T>> cache;
 
     public QNCache(boolean caseSensitiveKeys, Integer autoReleaseInSeconds, Long defaultKeepaliveInMillis) {
         this.caseSensitiveKeys = caseSensitiveKeys;
@@ -62,8 +63,6 @@ public class QNCache<T> {
     protected void setDateProvider(DateProvider dateProvider) {
         this.dateProvider = dateProvider;
     }
-
-    private ConcurrentHashMap<String, QNCacheBean<T>> cache;
 
     public void set(String key, T value) {
         if (defaultKeepaliveInMillis != null) {

--- a/src/main/java/com/fewlaps/quitnowcache/QNCacheBuilder.java
+++ b/src/main/java/com/fewlaps/quitnowcache/QNCacheBuilder.java
@@ -2,7 +2,7 @@ package com.fewlaps.quitnowcache;
 
 public class QNCacheBuilder {
     private boolean caseSensitiveKeys = true;
-    private Integer autoReleaseInSeconds = null;
+    private Integer autoReleaseInSeconds;
     private long defaultKeepaliveInMillis = QNCache.KEEPALIVE_FOREVER;
 
     public QNCacheBuilder setCaseSensitiveKeys(boolean caseSensitiveKeys) {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules squid:S3052 - Fields should not be initialized to default values
squid:S1213 - The members of an interface declaration or class should appear in a pre-defined order

You can find more information about the issues here:
https://dev.eclipse.org/sonar/coding_rules#q=squid:S3052
https://dev.eclipse.org/sonar/coding_rules#q=squid:S1213

Please let me know if you have any questions.

M-Ezzat