### PR TITLE
Java 8 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: java
 jdk:
   - oraclejdk8
-  - openjdk8
  
 before_install:
  - chmod +x gradlew

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,7 @@
 language: java
 jdk:
-  - oraclejdk7
   - oraclejdk8
-  - openjdk7
+  - openjdk8
  
 before_install:
  - chmod +x gradlew

--- a/build.gradle
+++ b/build.gradle
@@ -26,8 +26,8 @@ buildscript {
 }
 
 compileJava {
-    sourceCompatibility = 1.6
-    targetCompatibility = 1.6
+    sourceCompatibility = 1.8
+    targetCompatibility = 1.8
 }
 
 publish {

--- a/src/main/java/com/fewlaps/quitnowcache/DateProvider.java
+++ b/src/main/java/com/fewlaps/quitnowcache/DateProvider.java
@@ -4,11 +4,5 @@ interface DateProvider {
 
     long now();
 
-    DateProvider SYSTEM = new DateProvider() {
-
-        @Override
-        public long now() {
-            return System.currentTimeMillis();
-        }
-    };
+    DateProvider SYSTEM = System::currentTimeMillis;
 }

--- a/src/main/java/com/fewlaps/quitnowcache/QNCache.java
+++ b/src/main/java/com/fewlaps/quitnowcache/QNCache.java
@@ -82,10 +82,7 @@ public class QNCache<T> {
         }
     }
 
-    /**
-     * Gets an element from the cache.
-     */
-    public T get(String key) {
+    T get(String key) {
         key = getEffectiveKey(key);
 
         QNCacheBean<T> retrievedValue = cache.get(key);
@@ -96,14 +93,13 @@ public class QNCache<T> {
         }
     }
 
+    /**
+     * Gets an element from the cache.
+     */
     public Optional<T> getOptional(String key) {
         return Optional.ofNullable(get(key));
     }
 
-    /**
-     * Gets an element from the cache. If the element exists but it's dead,
-     * it will be removed of the cache, to free memory
-     */
     T getAndRemoveIfDead(String key) {
         key = getEffectiveKey(key);
 
@@ -118,6 +114,10 @@ public class QNCache<T> {
         }
     }
 
+    /**
+     * Gets an element from the cache. If the element exists but it's dead,
+     * it will be removed of the cache, to free memory
+     */
     Optional<T> getOptionalAndRemoveIfDead(String key) {
         return Optional.ofNullable(getAndRemoveIfDead(key));
     }

--- a/src/main/java/com/fewlaps/quitnowcache/QNCache.java
+++ b/src/main/java/com/fewlaps/quitnowcache/QNCache.java
@@ -82,7 +82,7 @@ public class QNCache<T> {
         }
     }
 
-    T get(String key) {
+    T maybeGet(String key) {
         key = getEffectiveKey(key);
 
         QNCacheBean<T> retrievedValue = cache.get(key);
@@ -96,11 +96,11 @@ public class QNCache<T> {
     /**
      * Gets an element from the cache.
      */
-    public Optional<T> getOptional(String key) {
-        return Optional.ofNullable(get(key));
+    public Optional<T> get(String key) {
+        return Optional.ofNullable(maybeGet(key));
     }
 
-    T getAndRemoveIfDead(String key) {
+    T maybeGetAndRemoveIfDead(String key) {
         key = getEffectiveKey(key);
 
         QNCacheBean<T> retrievedValue = cache.get(key);
@@ -118,8 +118,8 @@ public class QNCache<T> {
      * Gets an element from the cache. If the element exists but it's dead,
      * it will be removed of the cache, to free memory
      */
-    Optional<T> getOptionalAndRemoveIfDead(String key) {
-        return Optional.ofNullable(getAndRemoveIfDead(key));
+    Optional<T> getAndRemoveIfDead(String key) {
+        return Optional.ofNullable(maybeGetAndRemoveIfDead(key));
     }
 
     public void remove(String key) {
@@ -188,7 +188,7 @@ public class QNCache<T> {
     public boolean contains(String key) {
         key = getEffectiveKey(key);
 
-        return get(key) != null;
+        return maybeGet(key) != null;
     }
 
     /**

--- a/src/main/java/com/fewlaps/quitnowcache/QNCache.java
+++ b/src/main/java/com/fewlaps/quitnowcache/QNCache.java
@@ -2,6 +2,7 @@ package com.fewlaps.quitnowcache;
 
 import java.util.Iterator;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
@@ -95,6 +96,10 @@ public class QNCache<T> {
         }
     }
 
+    public Optional<T> getOptional(String key) {
+        return Optional.ofNullable(get(key));
+    }
+
     /**
      * Gets an element from the cache. If the element exists but it's dead,
      * it will be removed of the cache, to free memory
@@ -111,6 +116,10 @@ public class QNCache<T> {
             cache.remove(key);
             return null;
         }
+    }
+
+    Optional<T> getOptionalAndRemoveIfDead(String key) {
+        return Optional.ofNullable(getAndRemoveIfDead(key));
     }
 
     public void remove(String key) {

--- a/src/main/java/com/fewlaps/quitnowcache/QNCache.java
+++ b/src/main/java/com/fewlaps/quitnowcache/QNCache.java
@@ -26,7 +26,7 @@ public class QNCache<T> {
             this.defaultKeepaliveInMillis = defaultKeepaliveInMillis;
         }
 
-        cache = new ConcurrentHashMap<String, QNCacheBean<T>>();
+        cache = new ConcurrentHashMap<>();
 
         startAutoReleaseServiceIfNeeded();
     }
@@ -35,12 +35,7 @@ public class QNCache<T> {
         if (autoReleaseInSeconds != null) {
             ScheduledExecutorService ses = Executors.newSingleThreadScheduledExecutor();
 
-            ses.scheduleAtFixedRate(new Runnable() {
-                @Override
-                public void run() {
-                    removeTooOldValues();
-                }
-            }, autoReleaseInSeconds, autoReleaseInSeconds, TimeUnit.SECONDS);
+            ses.scheduleAtFixedRate(this::removeTooOldValues, autoReleaseInSeconds, autoReleaseInSeconds, TimeUnit.SECONDS);
         }
     }
 
@@ -78,7 +73,7 @@ public class QNCache<T> {
         key = getEffectiveKey(key);
 
         if (keepAliveInMillis >= 0) {
-            cache.put(key, new QNCacheBean<T>(value, now(), keepAliveInMillis));
+            cache.put(key, new QNCacheBean<>(value, now(), keepAliveInMillis));
         }
     }
 

--- a/src/test/java/com/fewlaps/quitnowcache/CaseSensitiveKeyTest.java
+++ b/src/test/java/com/fewlaps/quitnowcache/CaseSensitiveKeyTest.java
@@ -3,7 +3,7 @@ package com.fewlaps.quitnowcache;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertFalse;
 
 public class CaseSensitiveKeyTest extends BaseTest {
 
@@ -12,22 +12,22 @@ public class CaseSensitiveKeyTest extends BaseTest {
         QNCache<String> cache = new QNCacheBuilder().setCaseSensitiveKeys(false).createQNCache();
         cache.set(A_KEY.toLowerCase(), A_VALUE, FOREVER);
 
-        assertEquals(A_VALUE, cache.get(A_KEY.toUpperCase()));
+        assertEquals(A_VALUE, cache.getOptional(A_KEY.toUpperCase()).get());
     }
 
     @Test
-    public void shouldReturnNullIfUsingCaseSensitive() {
+    public void shouldReturnEmptyIfUsingCaseSensitive() {
         QNCache<String> cache = new QNCacheBuilder().setCaseSensitiveKeys(true).createQNCache();
         cache.set(A_KEY.toLowerCase(), A_VALUE, FOREVER);
 
-        assertNull(cache.get(A_KEY.toUpperCase()));
+        assertFalse(cache.getOptional(A_KEY.toUpperCase()).isPresent());
     }
 
     @Test
-    public void shouldReturnNullIfUsingDefaultBuilder() {
+    public void shouldReturnEmptyIfUsingDefaultBuilder() {
         QNCache<String> cache = new QNCacheBuilder().createQNCache();
         cache.set(A_KEY.toLowerCase(), A_VALUE, FOREVER);
 
-        assertNull(cache.get(A_KEY.toUpperCase()));
+        assertFalse(cache.getOptional(A_KEY.toUpperCase()).isPresent());
     }
 }

--- a/src/test/java/com/fewlaps/quitnowcache/CaseSensitiveKeyTest.java
+++ b/src/test/java/com/fewlaps/quitnowcache/CaseSensitiveKeyTest.java
@@ -12,7 +12,7 @@ public class CaseSensitiveKeyTest extends BaseTest {
         QNCache<String> cache = new QNCacheBuilder().setCaseSensitiveKeys(false).createQNCache();
         cache.set(A_KEY.toLowerCase(), A_VALUE, FOREVER);
 
-        assertEquals(A_VALUE, cache.getOptional(A_KEY.toUpperCase()).get());
+        assertEquals(A_VALUE, cache.get(A_KEY.toUpperCase()).get());
     }
 
     @Test
@@ -20,7 +20,7 @@ public class CaseSensitiveKeyTest extends BaseTest {
         QNCache<String> cache = new QNCacheBuilder().setCaseSensitiveKeys(true).createQNCache();
         cache.set(A_KEY.toLowerCase(), A_VALUE, FOREVER);
 
-        assertFalse(cache.getOptional(A_KEY.toUpperCase()).isPresent());
+        assertFalse(cache.get(A_KEY.toUpperCase()).isPresent());
     }
 
     @Test
@@ -28,6 +28,6 @@ public class CaseSensitiveKeyTest extends BaseTest {
         QNCache<String> cache = new QNCacheBuilder().createQNCache();
         cache.set(A_KEY.toLowerCase(), A_VALUE, FOREVER);
 
-        assertFalse(cache.getOptional(A_KEY.toUpperCase()).isPresent());
+        assertFalse(cache.get(A_KEY.toUpperCase()).isPresent());
     }
 }

--- a/src/test/java/com/fewlaps/quitnowcache/CastTest.java
+++ b/src/test/java/com/fewlaps/quitnowcache/CastTest.java
@@ -20,14 +20,14 @@ public class CastTest extends BaseTest {
     public void saveObjectAndReturnSameInstance() {
         cache.set(A_KEY, new ObjectTestOne());
 
-        assertThat(cache.get(A_KEY), instanceOf(ObjectTestOne.class));
+        assertThat(cache.getOptional(A_KEY).get(), instanceOf(ObjectTestOne.class));
     }
 
     @Test
     public void shouldCastObject() {
         cache.set(A_KEY, new ObjectTestOne());
 
-        ObjectTestOne objectTestOne = cache.get(A_KEY);
+        ObjectTestOne objectTestOne = cache.getOptional(A_KEY).get();
 
         assertThat(objectTestOne, instanceOf(ObjectTestOne.class));
     }

--- a/src/test/java/com/fewlaps/quitnowcache/CastTest.java
+++ b/src/test/java/com/fewlaps/quitnowcache/CastTest.java
@@ -20,14 +20,14 @@ public class CastTest extends BaseTest {
     public void saveObjectAndReturnSameInstance() {
         cache.set(A_KEY, new ObjectTestOne());
 
-        assertThat(cache.getOptional(A_KEY).get(), instanceOf(ObjectTestOne.class));
+        assertThat(cache.get(A_KEY).get(), instanceOf(ObjectTestOne.class));
     }
 
     @Test
     public void shouldCastObject() {
         cache.set(A_KEY, new ObjectTestOne());
 
-        ObjectTestOne objectTestOne = cache.getOptional(A_KEY).get();
+        ObjectTestOne objectTestOne = cache.get(A_KEY).get();
 
         assertThat(objectTestOne, instanceOf(ObjectTestOne.class));
     }

--- a/src/test/java/com/fewlaps/quitnowcache/DefaultKeepaliveTest.java
+++ b/src/test/java/com/fewlaps/quitnowcache/DefaultKeepaliveTest.java
@@ -18,7 +18,7 @@ public class DefaultKeepaliveTest extends BaseTest {
 
         dateProvider.setFixed(threeDaysFromNow());
 
-        assertNotNull(cache.getOptional(A_KEY).get());
+        assertNotNull(cache.get(A_KEY).get());
     }
 
     @Test
@@ -29,7 +29,7 @@ public class DefaultKeepaliveTest extends BaseTest {
 
         cache.set(A_KEY, A_VALUE);
 
-        assertNotNull(cache.getOptional(A_KEY).get());
+        assertNotNull(cache.get(A_KEY).get());
     }
 
     @Test
@@ -42,7 +42,7 @@ public class DefaultKeepaliveTest extends BaseTest {
 
         dateProvider.setFixed(oneSecondFromNow());
 
-        assertFalse(cache.getOptional(A_KEY).isPresent());
+        assertFalse(cache.get(A_KEY).isPresent());
     }
 
     @Test
@@ -55,7 +55,7 @@ public class DefaultKeepaliveTest extends BaseTest {
 
         dateProvider.setFixed(twoHoursFromNow());
 
-        assertFalse(cache.getOptional(A_KEY).isPresent());
+        assertFalse(cache.get(A_KEY).isPresent());
     }
 
     @Test
@@ -68,6 +68,6 @@ public class DefaultKeepaliveTest extends BaseTest {
 
         dateProvider.setFixed(oneSecondFromNow());
 
-        assertNotNull(cache.getOptional(A_KEY).get());
+        assertNotNull(cache.get(A_KEY).get());
     }
 }

--- a/src/test/java/com/fewlaps/quitnowcache/DefaultKeepaliveTest.java
+++ b/src/test/java/com/fewlaps/quitnowcache/DefaultKeepaliveTest.java
@@ -2,6 +2,7 @@ package com.fewlaps.quitnowcache;
 
 import org.junit.Test;
 
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 
@@ -17,7 +18,7 @@ public class DefaultKeepaliveTest extends BaseTest {
 
         dateProvider.setFixed(threeDaysFromNow());
 
-        assertNotNull(cache.get(A_KEY));
+        assertNotNull(cache.getOptional(A_KEY).get());
     }
 
     @Test
@@ -28,7 +29,7 @@ public class DefaultKeepaliveTest extends BaseTest {
 
         cache.set(A_KEY, A_VALUE);
 
-        assertNotNull(cache.get(A_KEY));
+        assertNotNull(cache.getOptional(A_KEY).get());
     }
 
     @Test
@@ -41,7 +42,7 @@ public class DefaultKeepaliveTest extends BaseTest {
 
         dateProvider.setFixed(oneSecondFromNow());
 
-        assertNull(cache.get(A_KEY));
+        assertFalse(cache.getOptional(A_KEY).isPresent());
     }
 
     @Test
@@ -54,7 +55,7 @@ public class DefaultKeepaliveTest extends BaseTest {
 
         dateProvider.setFixed(twoHoursFromNow());
 
-        assertNull(cache.get(A_KEY));
+        assertFalse(cache.getOptional(A_KEY).isPresent());
     }
 
     @Test
@@ -67,6 +68,6 @@ public class DefaultKeepaliveTest extends BaseTest {
 
         dateProvider.setFixed(oneSecondFromNow());
 
-        assertNotNull(cache.get(A_KEY));
+        assertNotNull(cache.getOptional(A_KEY).get());
     }
 }

--- a/src/test/java/com/fewlaps/quitnowcache/IntroducingQNCacheTest.java
+++ b/src/test/java/com/fewlaps/quitnowcache/IntroducingQNCacheTest.java
@@ -19,11 +19,11 @@ public class IntroducingQNCacheTest {
         cache.set("key", "value", 0); // or forever.
         cache.set("key", "value"); // And also for the short version of forever.
 
-        cache.get("key"); // It can get them again,
+        cache.getOptional("key").get(); // It can get them again,
         cache.remove("key"); // and remove it if you want.
 
-        cache.get("unExistingKey"); // If something doesn't exists, it returns null
-        cache.get("tooOldKey"); // The same if a key is too old
+        cache.getOptional("unExistingKey").isPresent(); // If something doesn't exists, it returns empty
+        cache.getOptional("tooOldKey").isPresent(); // The same if a key is too old
 
         cache.removeAll(); // You can also clean it,
         cache.size(); // and ask it how many elements it has

--- a/src/test/java/com/fewlaps/quitnowcache/IntroducingQNCacheTest.java
+++ b/src/test/java/com/fewlaps/quitnowcache/IntroducingQNCacheTest.java
@@ -2,9 +2,6 @@ package com.fewlaps.quitnowcache;
 
 import org.junit.Test;
 
-import java.util.ArrayList;
-import java.util.List;
-
 public class IntroducingQNCacheTest {
 
     @SuppressWarnings("UnusedAssignment")
@@ -19,11 +16,11 @@ public class IntroducingQNCacheTest {
         cache.set("key", "value", 0); // or forever.
         cache.set("key", "value"); // And also for the short version of forever.
 
-        cache.getOptional("key").get(); // It can get them again,
+        cache.get("key").get(); // It can get them again,
         cache.remove("key"); // and remove it if you want.
 
-        cache.getOptional("unExistingKey").isPresent(); // If something doesn't exists, it returns empty
-        cache.getOptional("tooOldKey").isPresent(); // The same if a key is too old
+        cache.get("unExistingKey").isPresent(); // If something doesn't exists, it returns empty
+        cache.get("tooOldKey").isPresent(); // The same if a key is too old
 
         cache.removeAll(); // You can also clean it,
         cache.size(); // and ask it how many elements it has

--- a/src/test/java/com/fewlaps/quitnowcache/MassiveDataTest.java
+++ b/src/test/java/com/fewlaps/quitnowcache/MassiveDataTest.java
@@ -20,7 +20,7 @@ public class MassiveDataTest extends BaseTest {
             cache.set(String.valueOf(i), i, 0);
         }
         for (Integer i = 0; i < iterations; i++) {
-            assertEquals(i, cache.get(String.valueOf(i)));
+            assertEquals(i, cache.getOptional(String.valueOf(i)).get());
         }
     }
 }

--- a/src/test/java/com/fewlaps/quitnowcache/MassiveDataTest.java
+++ b/src/test/java/com/fewlaps/quitnowcache/MassiveDataTest.java
@@ -20,7 +20,7 @@ public class MassiveDataTest extends BaseTest {
             cache.set(String.valueOf(i), i, 0);
         }
         for (Integer i = 0; i < iterations; i++) {
-            assertEquals(i, cache.getOptional(String.valueOf(i)).get());
+            assertEquals(i, cache.get(String.valueOf(i)).get());
         }
     }
 }

--- a/src/test/java/com/fewlaps/quitnowcache/SetAndGetValuesTest.java
+++ b/src/test/java/com/fewlaps/quitnowcache/SetAndGetValuesTest.java
@@ -24,14 +24,14 @@ public class SetAndGetValuesTest extends BaseTest {
     public void savingSomethingForOneSecondsShouldReturnTheSameImmediatelly() {
         cache.set(A_KEY, A_VALUE, ONE_SECOND);
 
-        assertEquals(A_VALUE, cache.get(A_KEY));
+        assertEquals(A_VALUE, cache.getOptional(A_KEY).get());
     }
 
     @Test
     public void savingSomethingForeverShouldReturnTheSameImmediatelly() {
         cache.set(A_KEY, A_VALUE, FOREVER);
 
-        assertEquals(A_VALUE, cache.get(A_KEY));
+        assertEquals(A_VALUE, cache.getOptional(A_KEY).get());
     }
 
     @Test
@@ -40,7 +40,7 @@ public class SetAndGetValuesTest extends BaseTest {
 
         dateProvider.setFixed(threeDaysFromNow());
 
-        assertEquals(A_VALUE, cache.get(A_KEY));
+        assertEquals(A_VALUE, cache.getOptional(A_KEY).get());
     }
 
     @Test
@@ -49,7 +49,7 @@ public class SetAndGetValuesTest extends BaseTest {
 
         dateProvider.setFixed(threeDaysFromNow());
 
-        assertEquals(A_VALUE, cache.get(A_KEY));
+        assertEquals(A_VALUE, cache.getOptional(A_KEY).get());
     }
 
     @Test
@@ -58,7 +58,7 @@ public class SetAndGetValuesTest extends BaseTest {
 
         dateProvider.setFixed(threeDaysFromNow());
 
-        assertNull(cache.get(A_KEY));
+        assertFalse(cache.getOptional(A_KEY).isPresent());
     }
 
     @Test
@@ -66,7 +66,7 @@ public class SetAndGetValuesTest extends BaseTest {
         cache.set(A_KEY, A_VALUE, -1);
         cache.set(ANOTHER_KEY, ANOTHER_VALUE, ONE_SECOND);
 
-        assertNull(cache.get(A_KEY));
+        assertFalse(cache.getOptional(A_KEY).isPresent());
         assertEquals(1, cache.size());
         assertEquals(1, cache.sizeCountingDeadAndAliveElements());
     }
@@ -76,7 +76,7 @@ public class SetAndGetValuesTest extends BaseTest {
         cache.set(A_KEY, A_VALUE, -1);
         cache.set(ANOTHER_KEY, ANOTHER_VALUE, THREE_DAYS);
 
-        assertNull(cache.getAndRemoveIfDead(A_KEY));
+        assertFalse(cache.getOptionalAndRemoveIfDead(A_KEY).isPresent());
         assertEquals(1, cache.size());
         assertEquals(1, cache.sizeCountingDeadAndAliveElements());
     }
@@ -88,7 +88,7 @@ public class SetAndGetValuesTest extends BaseTest {
 
         dateProvider.setFixed(twoHoursFromNow());
 
-        assertNull(cache.getAndRemoveIfDead(A_KEY));
+        assertFalse(cache.getOptionalAndRemoveIfDead(A_KEY).isPresent());
         assertEquals(1, cache.size());
         assertEquals(1, cache.sizeCountingDeadAndAliveElements());
     }
@@ -100,7 +100,7 @@ public class SetAndGetValuesTest extends BaseTest {
 
         dateProvider.setFixed(twoHoursFromNow());
 
-        assertEquals(ANOTHER_VALUE, cache.getAndRemoveIfDead(ANOTHER_KEY));
+        assertEquals(ANOTHER_VALUE, cache.getOptionalAndRemoveIfDead(ANOTHER_KEY).get());
         assertEquals(1, cache.size());
         assertEquals(2, cache.sizeCountingDeadAndAliveElements());
     }
@@ -112,8 +112,8 @@ public class SetAndGetValuesTest extends BaseTest {
 
         cache.remove(A_KEY);
 
-        assertNull(cache.get(A_KEY));
-        assertEquals(ANOTHER_VALUE, cache.get(ANOTHER_KEY));
+        assertFalse(cache.getOptional(A_KEY).isPresent());
+        assertEquals(ANOTHER_VALUE, cache.getOptional(ANOTHER_KEY).get());
     }
 
     @Test
@@ -123,8 +123,8 @@ public class SetAndGetValuesTest extends BaseTest {
 
         cache.removeAll();
 
-        assertNull(cache.get(A_KEY));
-        assertNull(cache.get(ANOTHER_KEY));
+        assertFalse(cache.getOptional(A_KEY).isPresent());
+        assertFalse(cache.getOptional(ANOTHER_KEY).isPresent());
     }
 
     @Test
@@ -132,7 +132,7 @@ public class SetAndGetValuesTest extends BaseTest {
         cache.set(A_KEY, A_VALUE, TWO_HOURS);
         cache.set(A_KEY, ANOTHER_VALUE, THREE_DAYS);
 
-        assertEquals(ANOTHER_VALUE, cache.get(A_KEY));
+        assertEquals(ANOTHER_VALUE, cache.getOptional(A_KEY).get());
     }
 
     @Test
@@ -142,7 +142,7 @@ public class SetAndGetValuesTest extends BaseTest {
 
         dateProvider.setFixed(twoHoursFromNow());
 
-        assertNull(cache.get(A_KEY));
+        assertFalse(cache.getOptional(A_KEY).isPresent());
     }
 
     @Test
@@ -150,7 +150,7 @@ public class SetAndGetValuesTest extends BaseTest {
         cache.set(A_KEY, A_VALUE, THREE_DAYS);
         cache.set(A_KEY, null, ONE_SECOND);
 
-        assertNull(cache.get(A_KEY));
+        assertFalse(cache.getOptional(A_KEY).isPresent());
     }
 
     @Test

--- a/src/test/java/com/fewlaps/quitnowcache/SetAndGetValuesTest.java
+++ b/src/test/java/com/fewlaps/quitnowcache/SetAndGetValuesTest.java
@@ -24,14 +24,14 @@ public class SetAndGetValuesTest extends BaseTest {
     public void savingSomethingForOneSecondsShouldReturnTheSameImmediatelly() {
         cache.set(A_KEY, A_VALUE, ONE_SECOND);
 
-        assertEquals(A_VALUE, cache.getOptional(A_KEY).get());
+        assertEquals(A_VALUE, cache.get(A_KEY).get());
     }
 
     @Test
     public void savingSomethingForeverShouldReturnTheSameImmediatelly() {
         cache.set(A_KEY, A_VALUE, FOREVER);
 
-        assertEquals(A_VALUE, cache.getOptional(A_KEY).get());
+        assertEquals(A_VALUE, cache.get(A_KEY).get());
     }
 
     @Test
@@ -40,7 +40,7 @@ public class SetAndGetValuesTest extends BaseTest {
 
         dateProvider.setFixed(threeDaysFromNow());
 
-        assertEquals(A_VALUE, cache.getOptional(A_KEY).get());
+        assertEquals(A_VALUE, cache.get(A_KEY).get());
     }
 
     @Test
@@ -49,7 +49,7 @@ public class SetAndGetValuesTest extends BaseTest {
 
         dateProvider.setFixed(threeDaysFromNow());
 
-        assertEquals(A_VALUE, cache.getOptional(A_KEY).get());
+        assertEquals(A_VALUE, cache.get(A_KEY).get());
     }
 
     @Test
@@ -58,7 +58,7 @@ public class SetAndGetValuesTest extends BaseTest {
 
         dateProvider.setFixed(threeDaysFromNow());
 
-        assertFalse(cache.getOptional(A_KEY).isPresent());
+        assertFalse(cache.get(A_KEY).isPresent());
     }
 
     @Test
@@ -66,7 +66,7 @@ public class SetAndGetValuesTest extends BaseTest {
         cache.set(A_KEY, A_VALUE, -1);
         cache.set(ANOTHER_KEY, ANOTHER_VALUE, ONE_SECOND);
 
-        assertFalse(cache.getOptional(A_KEY).isPresent());
+        assertFalse(cache.get(A_KEY).isPresent());
         assertEquals(1, cache.size());
         assertEquals(1, cache.sizeCountingDeadAndAliveElements());
     }
@@ -76,7 +76,7 @@ public class SetAndGetValuesTest extends BaseTest {
         cache.set(A_KEY, A_VALUE, -1);
         cache.set(ANOTHER_KEY, ANOTHER_VALUE, THREE_DAYS);
 
-        assertFalse(cache.getOptionalAndRemoveIfDead(A_KEY).isPresent());
+        assertFalse(cache.getAndRemoveIfDead(A_KEY).isPresent());
         assertEquals(1, cache.size());
         assertEquals(1, cache.sizeCountingDeadAndAliveElements());
     }
@@ -88,7 +88,7 @@ public class SetAndGetValuesTest extends BaseTest {
 
         dateProvider.setFixed(twoHoursFromNow());
 
-        assertFalse(cache.getOptionalAndRemoveIfDead(A_KEY).isPresent());
+        assertFalse(cache.getAndRemoveIfDead(A_KEY).isPresent());
         assertEquals(1, cache.size());
         assertEquals(1, cache.sizeCountingDeadAndAliveElements());
     }
@@ -100,7 +100,7 @@ public class SetAndGetValuesTest extends BaseTest {
 
         dateProvider.setFixed(twoHoursFromNow());
 
-        assertEquals(ANOTHER_VALUE, cache.getOptionalAndRemoveIfDead(ANOTHER_KEY).get());
+        assertEquals(ANOTHER_VALUE, cache.getAndRemoveIfDead(ANOTHER_KEY).get());
         assertEquals(1, cache.size());
         assertEquals(2, cache.sizeCountingDeadAndAliveElements());
     }
@@ -112,8 +112,8 @@ public class SetAndGetValuesTest extends BaseTest {
 
         cache.remove(A_KEY);
 
-        assertFalse(cache.getOptional(A_KEY).isPresent());
-        assertEquals(ANOTHER_VALUE, cache.getOptional(ANOTHER_KEY).get());
+        assertFalse(cache.get(A_KEY).isPresent());
+        assertEquals(ANOTHER_VALUE, cache.get(ANOTHER_KEY).get());
     }
 
     @Test
@@ -123,8 +123,8 @@ public class SetAndGetValuesTest extends BaseTest {
 
         cache.removeAll();
 
-        assertFalse(cache.getOptional(A_KEY).isPresent());
-        assertFalse(cache.getOptional(ANOTHER_KEY).isPresent());
+        assertFalse(cache.get(A_KEY).isPresent());
+        assertFalse(cache.get(ANOTHER_KEY).isPresent());
     }
 
     @Test
@@ -132,7 +132,7 @@ public class SetAndGetValuesTest extends BaseTest {
         cache.set(A_KEY, A_VALUE, TWO_HOURS);
         cache.set(A_KEY, ANOTHER_VALUE, THREE_DAYS);
 
-        assertEquals(ANOTHER_VALUE, cache.getOptional(A_KEY).get());
+        assertEquals(ANOTHER_VALUE, cache.get(A_KEY).get());
     }
 
     @Test
@@ -142,7 +142,7 @@ public class SetAndGetValuesTest extends BaseTest {
 
         dateProvider.setFixed(twoHoursFromNow());
 
-        assertFalse(cache.getOptional(A_KEY).isPresent());
+        assertFalse(cache.get(A_KEY).isPresent());
     }
 
     @Test
@@ -150,7 +150,7 @@ public class SetAndGetValuesTest extends BaseTest {
         cache.set(A_KEY, A_VALUE, THREE_DAYS);
         cache.set(A_KEY, null, ONE_SECOND);
 
-        assertFalse(cache.getOptional(A_KEY).isPresent());
+        assertFalse(cache.get(A_KEY).isPresent());
     }
 
     @Test

--- a/src/test/java/com/fewlaps/quitnowcache/SizeTest.java
+++ b/src/test/java/com/fewlaps/quitnowcache/SizeTest.java
@@ -50,8 +50,8 @@ public class SizeTest extends BaseTest {
 
         cache.removeAll();
 
-        assertNull(cache.get(A_KEY));
-        assertNull(cache.get(ANOTHER_KEY));
+        assertFalse(cache.getOptional(A_KEY).isPresent());
+        assertFalse(cache.getOptional(ANOTHER_KEY).isPresent());
 
         assertEquals(0, cache.size());
         assertEquals(0, cache.sizeCountingDeadAndAliveElements());
@@ -67,8 +67,8 @@ public class SizeTest extends BaseTest {
 
         cache.removeTooOldValues();
 
-        assertNull(cache.get(A_KEY));
-        assertEquals(ANOTHER_VALUE, cache.get(ANOTHER_KEY));
+        assertFalse(cache.getOptional(A_KEY).isPresent());
+        assertEquals(ANOTHER_VALUE, cache.getOptional(ANOTHER_KEY).get());
 
         assertEquals(1, cache.size());
         assertEquals(1, cache.sizeCountingDeadAndAliveElements());

--- a/src/test/java/com/fewlaps/quitnowcache/SizeTest.java
+++ b/src/test/java/com/fewlaps/quitnowcache/SizeTest.java
@@ -50,8 +50,8 @@ public class SizeTest extends BaseTest {
 
         cache.removeAll();
 
-        assertFalse(cache.getOptional(A_KEY).isPresent());
-        assertFalse(cache.getOptional(ANOTHER_KEY).isPresent());
+        assertFalse(cache.get(A_KEY).isPresent());
+        assertFalse(cache.get(ANOTHER_KEY).isPresent());
 
         assertEquals(0, cache.size());
         assertEquals(0, cache.sizeCountingDeadAndAliveElements());
@@ -67,8 +67,8 @@ public class SizeTest extends BaseTest {
 
         cache.removeTooOldValues();
 
-        assertFalse(cache.getOptional(A_KEY).isPresent());
-        assertEquals(ANOTHER_VALUE, cache.getOptional(ANOTHER_KEY).get());
+        assertFalse(cache.get(A_KEY).isPresent());
+        assertEquals(ANOTHER_VALUE, cache.get(ANOTHER_KEY).get());
 
         assertEquals(1, cache.size());
         assertEquals(1, cache.sizeCountingDeadAndAliveElements());

--- a/src/test/java/com/fewlaps/quitnowcache/SupplierTest.java
+++ b/src/test/java/com/fewlaps/quitnowcache/SupplierTest.java
@@ -1,0 +1,54 @@
+package com.fewlaps.quitnowcache;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Optional;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class SupplierTest {
+
+    private static final String A_KEY = "key";
+    private static final String SOME_VALUE = "value";
+    private static final String ANOTHER_VALUE = "another_value";
+
+    QNCache<String> cache;
+    MockDateProvider dateProvider;
+
+    @Before
+    public void init() {
+        cache = new QNCacheBuilder().createQNCache();
+        dateProvider = new MockDateProvider();
+        cache.setDateProvider(dateProvider);
+    }
+
+    @Test
+    public void testOldValueWhenPresent() throws Exception {
+        cache.set(A_KEY, SOME_VALUE);
+
+        String result = cache.getOrElseCache(A_KEY, () -> ANOTHER_VALUE);
+
+        assertEquals(SOME_VALUE, result);
+    }
+
+    @Test
+    public void testSuppliedValueWhenNotPresent() throws Exception {
+        // Empty cache
+
+        String result = cache.getOrElseCache(A_KEY, () -> ANOTHER_VALUE);
+
+        assertEquals(ANOTHER_VALUE, result);
+    }
+
+    @Test
+    public void testSuppliedIsCached() throws Exception {
+        cache.getOrElseCache(A_KEY, () -> ANOTHER_VALUE);
+
+        Optional<String> result = cache.get(A_KEY);
+
+        assertTrue(result.isPresent());
+        assertEquals(ANOTHER_VALUE, result.get());
+    }
+}

--- a/src/test/java/com/fewlaps/quitnowcache/ThreadSafeTest.java
+++ b/src/test/java/com/fewlaps/quitnowcache/ThreadSafeTest.java
@@ -60,7 +60,7 @@ public class ThreadSafeTest extends BaseTest {
             public void run() {
                 while (!writerFinished1.get() || !writerFinished2.get()) {
                     try {
-                        cache.get(RandomGenerator.generateRandomString());
+                        cache.maybeGet(RandomGenerator.generateRandomString());
                     } catch (Exception e) {
                         errors.set(errors.get() + 1);
                     }
@@ -131,7 +131,7 @@ public class ThreadSafeTest extends BaseTest {
             public void run() {
                 while (!writerFinished1.get() || !writerFinished2.get()) {
                     try {
-                        cache.getOptional(A_KEY);
+                        cache.get(A_KEY);
                     } catch (Exception e) {
                         errors.set(errors.get() + 1);
                     }

--- a/src/test/java/com/fewlaps/quitnowcache/ThreadSafeTest.java
+++ b/src/test/java/com/fewlaps/quitnowcache/ThreadSafeTest.java
@@ -131,7 +131,7 @@ public class ThreadSafeTest extends BaseTest {
             public void run() {
                 while (!writerFinished1.get() || !writerFinished2.get()) {
                     try {
-                        cache.get(A_KEY);
+                        cache.getOptional(A_KEY);
                     } catch (Exception e) {
                         errors.set(errors.get() + 1);
                     }


### PR DESCRIPTION
> **Warning:** Do not accept this PR, it would break things.

Hey. Instead of writing a write-only version of quitnow-cache, I decided to have a more productive coding session and try to adapt the code for Java 8. Did it just for fun.

I changed the nullable methods to return Optionals instead, replaced some interfaces with lambdas, and used Stream somewhere. I also added a couple of methods to provide a fallback value, mimicking the API of Optional.orElse().

I don't recommend accepting this PR because it will break compatibility with older versions of Java, and also with Android. You can just close it.